### PR TITLE
Decode return value of magic.from_buffer() as UTF-8

### DIFF
--- a/fuglu/src/fuglu/plugins/attachment.py
+++ b/fuglu/src/fuglu/plugins/attachment.py
@@ -483,7 +483,7 @@ The other common template variables are available as well.
             ms = self._get_file_magic()
             btype = ms.buffer(buffercontent)
         elif MAGIC_AVAILABLE == MAGIC_PYTHON_MAGIC:
-            btype = magic.from_buffer(buffercontent, mime=True)
+            btype = magic.from_buffer(buffercontent, mime=True).decode('utf-8')
         return btype
 
     def asciionly(self, stri):

--- a/fuglu/src/fuglu/plugins/attachment.py
+++ b/fuglu/src/fuglu/plugins/attachment.py
@@ -483,7 +483,9 @@ The other common template variables are available as well.
             ms = self._get_file_magic()
             btype = ms.buffer(buffercontent)
         elif MAGIC_AVAILABLE == MAGIC_PYTHON_MAGIC:
-            btype = magic.from_buffer(buffercontent, mime=True).decode('utf-8')
+            btype = magic.from_buffer(buffercontent, mime=True)
+            if isinstance(btype, bytes) and sys.version_info > (3,):
+                btype = btype.decode('UTF-8', 'ignore')
         return btype
 
     def asciionly(self, stri):


### PR DESCRIPTION
When running with python-magic under Python 3.4, magic.from_buffer() returns a byte string which causes the 'in' test in attachment.py:701 to fail.
As a result plugins_attachment_test.test_archive_wrong_extension fails