### PR TITLE
Save the localpart of the sender and recipient address as fields in the Suspect class

### DIFF
--- a/fuglu/src/fuglu/shared.py
+++ b/fuglu/src/fuglu/shared.py
@@ -205,15 +205,16 @@ class Suspect(object):
             self.from_address = ''
 
         try:
-            (user, self.to_domain) = self.to_address.rsplit('@', 1)
+            (self.to_localpart, self.to_domain) = self.to_address.rsplit('@', 1)
         except:
             raise ValueError("invalid to email address: %s" % self.to_address)
 
         if self.from_address == '':
             self.from_domain = ''
+            self.from_localpart = ''
         else:
             try:
-                (user, self.from_domain) = self.from_address.rsplit('@', 1)
+                (self.from_localpart, self.from_domain) = self.from_address.rsplit('@', 1)
             except Exception as e:
                 raise ValueError(
                     "invalid from email address: '%s'" % self.from_address)

--- a/fuglu/tests/unit/shared_test.py
+++ b/fuglu/tests/unit/shared_test.py
@@ -33,6 +33,17 @@ class SuspectTestCase(unittest.TestCase):
             for c in suspect_id:
                 self.assertTrue(c in string.hexdigits)
 
+    def test_from_to_parsing(self):
+        s = Suspect('sender@example.com', 'recipient@example.com', '/dev/null')
+
+        self.assertEqual("sender@example.com", s.from_address)
+        self.assertEqual("sender", s.from_localpart)
+        self.assertEqual("example.com", s.from_domain)
+
+        self.assertEqual("recipient@example.com", s.to_address)
+        self.assertEqual("recipient", s.to_localpart)
+        self.assertEqual("example.com", s.to_domain)
+
 
 class SuspectFilterTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Save the localpart of the sender and recipient address as fields in the Suspect class.