### PR TITLE
[WIP] Remove obsolete S/MIME check (bug #84 )

### DIFF
--- a/fuglu/src/fuglu/connectors/smtpconnector.py
+++ b/fuglu/src/fuglu/connectors/smtpconnector.py
@@ -54,14 +54,6 @@ class SMTPHandler(ProtocolHandler):
         ProtocolHandler.__init__(self, socket, config)
         self.sess = SMTPSession(socket, config)
 
-    def is_signed(self, suspect):
-        msgrep = suspect.get_message_rep()
-        if 'Content-Type' in msgrep:
-            ctype = msgrep['Content-Type'].lower()
-            if 'multipart/signed' in ctype or 'application/pkcs7-mime' in ctype:
-                return True
-        return False
-
     def re_inject(self, suspect):
         """Send message back to postfix"""
         if suspect.get_tag('noreinject'):
@@ -70,10 +62,6 @@ class SMTPHandler(ProtocolHandler):
         if suspect.get_tag('reinjectoriginal'):
             self.logger.info(
                 '%s: Injecting original message source without modifications' % suspect.id)
-            msgcontent = suspect.get_original_source()
-        elif self.is_signed(suspect):
-            self.logger.info(
-                '%s: S/MIME signed message detected - sending original source without modifications' % suspect.id)
             msgcontent = suspect.get_original_source()
         else:
             msgcontent = buildmsgsource(suspect)


### PR DESCRIPTION
This was a ugly restriction to make sure that fuglu never breaks signatures.
If such a case pops up we should fix the problem, not work around it.