### PR TITLE
Support IPv6 connections to external daemons

### DIFF
--- a/fuglu/src/fuglu/plugins/clamav.py
+++ b/fuglu/src/fuglu/plugins/clamav.py
@@ -276,7 +276,10 @@ Tags:
                     'Could not reach clamd using unix socket %s' % sock)
         else:
             clamd_PORT = int(self.config.get(self.section, 'port'))
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            proto = socket.AF_INET
+            if ':' in clamd_HOST:
+                proto = socket.AF_INET6
+            s = socket.socket(proto, socket.SOCK_STREAM)
             s.settimeout(socktimeout)
             try:
                 s.connect((clamd_HOST, clamd_PORT))

--- a/fuglu/src/fuglu/plugins/drweb.py
+++ b/fuglu/src/fuglu/plugins/drweb.py
@@ -198,11 +198,15 @@ Tags:
             return None
 
     def __init_socket__(self):
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        host = self.config.get(self.section, 'host')
+        port = self.config.getint(self.section, 'port')
+        proto = socket.AF_INET
+        if ':' in host:
+            proto = socket.AF_INET6
+        s = socket.socket(proto, socket.SOCK_STREAM)
         s.settimeout(self.config.getint(self.section, 'timeout'))
         try:
-            s.connect((self.config.get(self.section, 'host'),
-                       self.config.getint(self.section, 'port')))
+            s.connect((host,port))
         except socket.error:
             raise Exception('Could not reach drweb using network (%s, %s)' % (
                 self.config.get(self.section, 'host'), self.config.getint(self.section, 'port')))

--- a/fuglu/src/fuglu/plugins/fprot.py
+++ b/fuglu/src/fuglu/plugins/fprot.py
@@ -220,11 +220,15 @@ Tags:
         return self._parse_result(result)
 
     def __init_socket__(self):
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        host = self.config.get(self.section, 'host')
+        port = self.config.getint(self.section, 'port')
+        proto = socket.AF_INET
+        if ':' in host:
+            proto = socket.AF_INET6
+        s = socket.socket(proto, socket.SOCK_STREAM)
         s.settimeout(self.config.getint(self.section, 'timeout'))
         try:
-            s.connect((self.config.get(self.section, 'host'),
-                       self.config.getint(self.section, 'port')))
+            s.connect((host,port))
         except socket.error:
             raise Exception('Could not reach fpscand using network (%s, %s)' % (
                 self.config.get(self.section, 'host'), self.config.getint(self.section, 'port')))

--- a/fuglu/src/fuglu/plugins/icap.py
+++ b/fuglu/src/fuglu/plugins/icap.py
@@ -242,7 +242,10 @@ Prerequisites: requires an ICAP capable antivirus engine somewhere in your netwo
                     'Could not reach ICAP server using unix socket %s' % sock)
         else:
             icap_PORT = int(self.config.get(self.section, 'port'))
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            proto = socket.AF_INET
+            if ':' in icap_HOST:
+                proto = socket.AF_INET6
+            s = socket.socket(proto, socket.SOCK_STREAM)
             s.settimeout(self.config.getint(self.section, 'timeout'))
             try:
                 s.connect((icap_HOST, icap_PORT))

--- a/fuglu/src/fuglu/plugins/sa.py
+++ b/fuglu/src/fuglu/plugins/sa.py
@@ -471,7 +471,10 @@ Tags:
                 raise Exception(
                     'Could not reach spamd using unix socket %s' % sock)
         else:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            proto = socket.AF_INET
+            if ':' in host:
+                proto = socket.AF_INET6
+            s = socket.socket(proto, socket.SOCK_STREAM)
             s.settimeout(self.config.getint(self.section, 'timeout'))
             try:
                 s.connect((host, port))

--- a/fuglu/src/fuglu/plugins/sssp.py
+++ b/fuglu/src/fuglu/plugins/sssp.py
@@ -353,7 +353,10 @@ Prerequisites: Requires a running sophos daemon with dynamic interface (SAVDI)
                     'Could not reach SSSP server using unix socket %s' % sock)
         else:
             sssp_PORT = iport
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            proto = socket.AF_INET
+            if ':' in sssp_HOST:
+                proto = socket.AF_INET6
+            s = socket.socket(proto, socket.SOCK_STREAM)
             s.settimeout(self.config.getint(self.section, 'timeout'))
             try:
                 s.connect((sssp_HOST, sssp_PORT))


### PR DESCRIPTION
we simply check for ':' in the host and switch to AF_INET6 if found. For hostnames without ':' we still try ipv4 only. In the future we could try ipv6 first and then fallback to ipv4, but at the moment I feel this will only cause a performance hit in most setups. 