### PR TITLE
WIP: Multiprocessing

### DIFF
--- a/fuglu/src/fuglu/connectors/esmtpconnector.py
+++ b/fuglu/src/fuglu/connectors/esmtpconnector.py
@@ -46,6 +46,7 @@ def buildmsgsource(suspect):
 
 
 class ESMTPHandler(ProtocolHandler):
+    protoname = 'ESMTP (before queue)'
 
     def __init__(self, socket, config):
         ProtocolHandler.__init__(self, socket, config)

--- a/fuglu/src/fuglu/connectors/smtpconnector.py
+++ b/fuglu/src/fuglu/connectors/smtpconnector.py
@@ -47,7 +47,7 @@ def buildmsgsource(suspect):
 
 
 class SMTPHandler(ProtocolHandler):
-    protoname = 'SMTP (After Queue)'
+    protoname = 'SMTP (after queue)'
 
     def __init__(self, socket, config):
         ProtocolHandler.__init__(self, socket, config)

--- a/fuglu/src/fuglu/core.py
+++ b/fuglu/src/fuglu/core.py
@@ -647,16 +647,17 @@ class MainController(object):
         self.logger.info('Applying configuration changes...')
 
         # threadpool changes?
-        minthreads = self.config.getint('performance', 'minthreads')
-        maxthreads = self.config.getint('performance', 'maxthreads')
+        if self.config.get('performance','backend') == 'thread' and self.threadpool is not None:
+            minthreads = self.config.getint('performance', 'minthreads')
+            maxthreads = self.config.getint('performance', 'maxthreads')
 
-        if self.threadpool.minthreads != minthreads or self.threadpool.maxthreads != maxthreads:
-            self.logger.info(
-                'Threadpool config changed, initialising new threadpool')
-            queuesize = maxthreads * 10
-            currentthreadpool = self.threadpool
-            self.threadpool = ThreadPool(minthreads, maxthreads, queuesize)
-            currentthreadpool.stayalive = False
+            if self.threadpool.minthreads != minthreads or self.threadpool.maxthreads != maxthreads:
+                self.logger.info(
+                    'Threadpool config changed, initialising new threadpool')
+                queuesize = maxthreads * 10
+                currentthreadpool = self.threadpool
+                self.threadpool = ThreadPool(minthreads, maxthreads, queuesize)
+                currentthreadpool.stayalive = False
 
         # smtp engine changes?
         ports = self.config.get('main', 'incomingport')

--- a/fuglu/src/fuglu/debug.py
+++ b/fuglu/src/fuglu/debug.py
@@ -151,11 +151,17 @@ class ControlSession(object):
     def workerlist(self, args):
         """list of mail scanning workers"""
         threadpool = self.controller.threadpool
+        res=""
         if threadpool is not None:
             workerlist = "\n%s" % '\n*******\n'.join(map(repr, threadpool.workers))
-            res = "Total %s Threads\n%s" % (len(threadpool.workers), workerlist)
-        else:
-            res = "Threadpool is disabled"
+            res += "Total %s worker threads\n%s" % (len(threadpool.workers), workerlist)
+
+        procpool = self.controller.procpool
+        if procpool is not None:
+            childstate_dict = procpool.shared_state
+            workerlist = "\n%s" % '\n*******\n'.join(["%s: %s"%(procname,procstate) for procname,procstate in childstate_dict.items()])
+            res += "Total %s worker processes\n%s" % (len(procpool.workers), workerlist)
+
         return res
 
     def threadlist(self, args):

--- a/fuglu/src/fuglu/debug.py
+++ b/fuglu/src/fuglu/debug.py
@@ -151,8 +151,11 @@ class ControlSession(object):
     def workerlist(self, args):
         """list of mail scanning workers"""
         threadpool = self.controller.threadpool
-        workerlist = "\n%s" % '\n*******\n'.join(map(repr, threadpool.workers))
-        res = "Total %s Threads\n%s" % (len(threadpool.workers), workerlist)
+        if threadpool is not None:
+            workerlist = "\n%s" % '\n*******\n'.join(map(repr, threadpool.workers))
+            res = "Total %s Threads\n%s" % (len(threadpool.workers), workerlist)
+        else:
+            res = "Threadpool is disabled"
         return res
 
     def threadlist(self, args):

--- a/fuglu/src/fuglu/debug.py
+++ b/fuglu/src/fuglu/debug.py
@@ -198,10 +198,11 @@ class ControlSession(object):
 ---------------
 Uptime:\t\t${uptime}
 Avg scan time:\t${scantime}
-Total msgs:\t${totalcount}
+Total msgs:\t${totalcount} in:${incount} out:${outcount}
 Ham:\t\t${hamcount}
 Spam:\t\t${spamcount}
 Virus:\t\t${viruscount}
+Block:\t\t${blockedcount}
         """
         renderer = string.Template(template)
         vrs = dict(
@@ -210,7 +211,10 @@ Virus:\t\t${viruscount}
             totalcount=stats.totalcount,
             hamcount=stats.hamcount,
             viruscount=stats.viruscount,
-            spamcount=stats.spamcount
+            spamcount=stats.spamcount,
+            incount=stats.incount,
+            outcount=stats.outcount,
+            blockedcount=stats.blockedcount,
         )
         res = renderer.safe_substitute(vrs)
         return res

--- a/fuglu/src/fuglu/procpool.py
+++ b/fuglu/src/fuglu/procpool.py
@@ -1,0 +1,101 @@
+#   Copyright 2009-2017 Oli Schacher
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+#
+import multiprocessing
+import multiprocessing.queues
+
+from fuglu.scansession import SessionHandler
+import fuglu.core
+import logging
+import traceback
+import importlib
+import pickle
+
+class ProcManager(object):
+    def __init__(self, numprocs = None, queuesize=100, config = None):
+        self.config = config
+        self.numprocs = numprocs
+        self.workers = []
+        self.queuesize = queuesize
+        self.tasks = multiprocessing.queues.Queue(queuesize)
+
+        self.logger = logging.getLogger('%s.procpool' % __package__)
+        self._stayalive = True
+        self.name = 'ProcessPool'
+        self.start()
+
+    @property
+    def stayalive(self):
+        return self._stayalive
+
+    @stayalive.setter
+    def stayalive(self, value):
+        # procpool is shut down -> send poison pill to workers
+        if self._stayalive and not value:
+            self._stayalive = False
+            self._send_poison_pills()
+        self._stayalive = value
+
+    def _send_poison_pills(self):
+        """flood the queue with poison pills to tell all workers to shut down"""
+        for _ in range(len(self.workers)):
+            self.tasks.put_nowait(None)
+
+    def add_task(self, session):
+        if self._stayalive:
+            self.tasks.put(session)
+
+    def start(self):
+        for i in range(self.numprocs):
+            worker = multiprocessing.Process(target=fuglu_process_worker, args=(self.tasks,self.config))
+            worker.start()
+            self.workers.append(worker)
+
+    def shutdown(self):
+        self. stayalive = False
+
+
+def fuglu_process_worker(queue, config):
+    logging.basicConfig(level=logging.DEBUG)
+
+    logger = logging.getLogger('fuglu.process')
+    logger.debug("Child ready")
+
+    # load config and plugins
+    controller = fuglu.core.MainController(config)
+    controller.load_extensions()
+    controller.load_plugins()
+    prependers = controller.prependers
+    plugins = controller.plugins
+    appenders = controller.appenders
+
+    try:
+        while True:
+            task = queue.get()
+            if task is None: # poison pill
+                logger.debug("Child process received poison pill - shut down")
+                return
+            pickled_socket, handler_modulename, handler_classname = task
+            sock = pickle.loads(pickled_socket)
+            handler_class = getattr(importlib.import_module(handler_modulename), handler_classname)
+            handler_instance = handler_class(sock, config)
+            handler = SessionHandler(handler_instance, config,prependers, plugins, appenders)
+            handler.handlesession()
+    except:
+        trb = traceback.format_exc()
+        logger.error("Exception in child process: %s"%trb)
+
+

--- a/fuglu/src/fuglu/scansession.py
+++ b/fuglu/src/fuglu/scansession.py
@@ -18,7 +18,7 @@
 from fuglu.shared import DUNNO, ACCEPT, REJECT, DEFER, DELETE
 from fuglu.debug import CrashStore
 import logging
-from fuglu.stats import Statskeeper
+from fuglu.stats import Statskeeper, StatDelta
 import sys
 import traceback
 import tempfile
@@ -53,12 +53,11 @@ class SessionHandler(object):
         prependheader = self.config.get('main', 'prependaddedheaders')
         try:
             self.set_workerstate('receiving message')
-
-            self.stats.incount += 1
             suspect = self.protohandler.get_suspect()
             if suspect is None:
                 self.logger.error('No Suspect retrieved, ending session')
                 return
+            self.stats.increase_counter_values(StatDelta(in_=1))
 
             if len(suspect.recipients) != 1:
                 self.logger.warning('Notice: Message from %s has %s recipients. Plugins supporting only one recipient will see: %s' % (
@@ -115,7 +114,7 @@ class SessionHandler(object):
             if result == ACCEPT or result == DUNNO:
                 try:
                     self.protohandler.commitback(suspect)
-                    self.stats.outcount += 1
+                    self.stats.increase_counter_values(StatDelta(out=1))
 
                 except KeyboardInterrupt:
                     sys.exit()

--- a/fuglu/src/fuglu/threadpool.py
+++ b/fuglu/src/fuglu/threadpool.py
@@ -154,16 +154,16 @@ class Worker(threading.Thread):
         self.logger.debug('thread init')
         self.noisy = False
         self.setDaemon(False)
-        self.threadinfo = 'created'
+        self.workerstate = 'created'
 
     def __repr__(self):
-        return "%s: %s" % (self.workerid, self.threadinfo)
+        return "%s: %s" % (self.workerid, self.workerstate)
 
     def run(self):
         self.logger.debug('thread start')
 
         while self.stayalive:
-            self.threadinfo = 'waiting for task'
+            self.workerstate = 'waiting for task'
             if self.noisy:
                 self.logger.debug('Getting new task...')
             sesshandler = self.pool.get_task()
@@ -179,7 +179,7 @@ class Worker(threading.Thread):
                 sesshandler.handlesession(self)
             except Exception as e:
                 self.logger.error('Unhandled Exception : %s' % e)
-            self.threadinfo = 'task completed'
+            self.workerstate = 'task completed'
 
-        self.threadinfo = 'ending'
+        self.workerstate = 'ending'
         self.logger.debug('thread end')


### PR DESCRIPTION
This pull request adds multiprocessing support as requested in #78 .
The setup is quite similar to the existing threading model:
 - instead of a thread pool, we start a number of processes
 - each process accesses a shared queue to handle each request

There are however a few differences:
 - Each worker loads its on copy of the configuration and plugin instances (a minimal version of the fuglu MainController)
 - To minimize IPC overhead, only the socket and name of connection handler are passed from the main process to the children. Each child process builds the SessionHandler itself, whereas this is done on the socketserver in the threading model

current state: basic implementations seems to work fine, my spamtrap runs in this mode without (obvious) issues

to **enable** multiprocessing instead of the threadpool:
``` 
[performance]
backend=process

# set a number of processes
# 0 to automatically select twice the amount of virtual cores
initialprocs=0
```
**current limitations/bugs**
(some of which we might fix, some might still be there in the merged version):

- ~~no process inspection.  `fuglu_control workerlist` will not show any process states~~
- ~~no statistics - each process currently has its own statistic counter which is not yet propagated to the main process~~
- no auto-adaptation of the number of processes
- no max lifetime per child process - they will run as long as the main process
- no config reloading on the fly - fuglu must be restarted for config changes to take effect
- the socket is not correctly closed if the client issues "quit" without terminating the socket itself