### PR TITLE
Fixed StringIO import for python3

### DIFF
--- a/fuglu/src/fuglu/protocolbase.py
+++ b/fuglu/src/fuglu/protocolbase.py
@@ -20,7 +20,10 @@ import threading
 from fuglu.scansession import SessionHandler
 import traceback
 from multiprocessing.reduction import ForkingPickler
-import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 class ProtocolHandler(object):
     protoname = 'UNDEFINED'


### PR DESCRIPTION
This fixes StringIO import when running Fuglu with python3 (package was moved to io.StringIO)