### PR TITLE
Add support for IPv6 in core and plugins

### DIFF
--- a/fuglu/src/fuglu/core.py
+++ b/fuglu/src/fuglu/core.py
@@ -589,17 +589,19 @@ class MainController(object):
         terp = code.InteractiveConsole(locals())
         terp.interact("")
 
-    def run_netconsole(self, port=1337, bind="0.0.0.0"):
+    def run_netconsole(self, port=1337, address="0.0.0.0"):
         """start a network console"""
         old_stdin = sys.stdin
         old_stdout = sys.stdout
         old_stderr = sys.stderr
 
-        serversocket = socket.socket()
+        addr_f = socket.getaddrinfo(address, 0)[0][0]
+
+        serversocket = socket.socket(addr_f)
         serversocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        serversocket.bind((bind, port))
+        serversocket.bind((address, port))
         serversocket.listen(1)
-        clientsocket, address = serversocket.accept()  # client socket
+        clientsocket, _ = serversocket.accept()  # client socket
         self.logger.info("Interactive python connection from %s/%s" % (address[0], address[1]))
 
         class sw:  # socket wrapper
@@ -627,7 +629,7 @@ class MainController(object):
         except:
             pass
         self.logger.info(
-            "done talking to %s - closing interactive shell on %s/%s" % (address[0], bind, port))
+            "done talking to %s - closing interactive shell on %s/%s" % (address, address, port))
         sys.stdin = old_stdin
         sys.stdout = old_stdout
         sys.stderr = old_stderr
@@ -987,3 +989,4 @@ class MainController(object):
                 raise Exception('Cannot set Config Section %s : Plugin %s does not support config override' % (
                     configsection, mod))
         return plugininstance
+

--- a/fuglu/src/fuglu/debug.py
+++ b/fuglu/src/fuglu/debug.py
@@ -36,7 +36,7 @@ class ControlServer(object):
                 pass
 
         if isinstance(port, int):
-            porttype = "inet4"
+            porttype = "inet"
             self.logger = logging.getLogger("fuglu.control.%s" % port)
             self.logger.debug('Starting Control/Info server on port %s' % port)
         else:
@@ -50,9 +50,10 @@ class ControlServer(object):
         self.stayalive = 1
 
         try:
-            if porttype == "inet4":
+            if porttype == "inet":
+                addr_f = socket.getaddrinfo(address, 0)[0][0]
                 self._socket = socket.socket(
-                    socket.AF_INET, socket.SOCK_STREAM)
+                    addr_f, socket.SOCK_STREAM)
                 self._socket.setsockopt(
                     socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                 self._socket.bind((address, port))
@@ -240,3 +241,4 @@ class CrashStore(object):
         CrashStore.exceptions.append((exc_info, time.time(), desc),)
         while len(CrashStore.exceptions) > maxtracebacks:
             CrashStore.exceptions.pop(0)
+

--- a/fuglu/src/fuglu/plugins/a_statsd.py
+++ b/fuglu/src/fuglu/plugins/a_statsd.py
@@ -1,6 +1,6 @@
 from fuglu.shared import AppenderPlugin, actioncode_to_string
 import platform
-from socket import socket, AF_INET, SOCK_DGRAM
+from socket import socket
 
 
 class PluginTime(AppenderPlugin):
@@ -32,7 +32,8 @@ class PluginTime(AppenderPlugin):
 
         buffer = ""
         if self.sock == None:
-            self.sock = socket(AF_INET, SOCK_DGRAM)
+            addr_f = socket.getaddrinfo(address, 0)[0][0]
+            self.sock = socket(addr_f, socket.SOCK_DGRAM)
 
         for section, time in timings:
             buffer = "%s%s.fuglu.plugin.%s:%s|ms\n" % (
@@ -71,7 +72,8 @@ class MessageStatus(AppenderPlugin):
         buffer = "%s.fuglu.decision.%s:1|c\n" % (
             self.nodename, actioncode_to_string(decision))
         if self.sock == None:
-            self.sock = socket(AF_INET, SOCK_DGRAM)
+            addr_f = socket.getaddrinfo(address, 0)[0][0]
+            self.sock = socket(addr_f, socket.SOCK_DGRAM)
 
         if suspect.is_virus():
             buffer = "%s%s.fuglu.message.virus:1|c\n" % (buffer, self.nodename)
@@ -126,7 +128,8 @@ class MessageStatusPerRecipient(AppenderPlugin):
 
         buffer = ""
         if self.sock == None:
-            self.sock = socket(AF_INET, SOCK_DGRAM)
+            addr_f = socket.getaddrinfo(address, 0)[0][0]
+            self.sock = socket(addr_f, socket.SOCK_DGRAM)
 
         if suspect.is_virus():
             buffer = "%s%s.fuglu.recipient.%s.virus:1|c\n" % (
@@ -148,3 +151,4 @@ class MessageStatusPerRecipient(AppenderPlugin):
 
     def __str__(self):
         return 'Statsd Sender: Per Recipient Message Status'
+

--- a/fuglu/src/fuglu/plugins/drweb.py
+++ b/fuglu/src/fuglu/plugins/drweb.py
@@ -200,16 +200,11 @@ Tags:
     def __init_socket__(self):
         host = self.config.get(self.section, 'host')
         port = self.config.getint(self.section, 'port')
-        proto = socket.AF_INET
-        if ':' in host:
-            proto = socket.AF_INET6
-        s = socket.socket(proto, socket.SOCK_STREAM)
-        s.settimeout(self.config.getint(self.section, 'timeout'))
+        timeout = self.config.getint(self.section, 'timeout')
         try:
-            s.connect((host,port))
+            s = socket.create_connection((host, port), timeout)
         except socket.error:
-            raise Exception('Could not reach drweb using network (%s, %s)' % (
-                self.config.get(self.section, 'host'), self.config.getint(self.section, 'port')))
+            raise Exception('Could not reach drweb using network (%s, %s)' % (host, port))
 
         return s
 
@@ -343,3 +338,4 @@ if __name__ == '__main__':
         print("%s / %s files infected" % (infected, counter))
     else:
         plugin.lint_eicar()
+

--- a/fuglu/src/fuglu/plugins/fprot.py
+++ b/fuglu/src/fuglu/plugins/fprot.py
@@ -21,7 +21,7 @@ import os
 
 class FprotPlugin(ScannerPlugin):
 
-    """ This plugin passes suspects to a f-prot scan daemon 
+    """ This plugin passes suspects to a f-prot scan daemon
 
 Prerequisites: f-protd must be installed and running, not necessarily on the same box as fuglu though.
 
@@ -222,13 +222,9 @@ Tags:
     def __init_socket__(self):
         host = self.config.get(self.section, 'host')
         port = self.config.getint(self.section, 'port')
-        proto = socket.AF_INET
-        if ':' in host:
-            proto = socket.AF_INET6
-        s = socket.socket(proto, socket.SOCK_STREAM)
-        s.settimeout(self.config.getint(self.section, 'timeout'))
+        socktimeout = self.config.getint(self.section, 'timeout')
         try:
-            s.connect((host,port))
+            s = socket.create_connection((host, port), socktimeout)
         except socket.error:
             raise Exception('Could not reach fpscand using network (%s, %s)' % (
                 self.config.get(self.section, 'host'), self.config.getint(self.section, 'port')))
@@ -273,3 +269,4 @@ AAEAAQA3AAAAbQAAAAAA
             return False
         print("F-Prot found virus", result)
         return True
+

--- a/fuglu/src/fuglu/plugins/icap.py
+++ b/fuglu/src/fuglu/plugins/icap.py
@@ -221,11 +221,10 @@ Prerequisites: requires an ICAP capable antivirus engine somewhere in your netwo
             return dr
 
     def __init_socket__(self):
-        icap_HOST = self.config.get(self.section, 'host')
         unixsocket = False
 
         try:
-            iport = int(self.config.get(self.section, 'port'))
+            int(self.config.get(self.section, 'port'))
         except ValueError:
             unixsocket = True
 
@@ -241,17 +240,14 @@ Prerequisites: requires an ICAP capable antivirus engine somewhere in your netwo
                 raise Exception(
                     'Could not reach ICAP server using unix socket %s' % sock)
         else:
-            icap_PORT = int(self.config.get(self.section, 'port'))
-            proto = socket.AF_INET
-            if ':' in icap_HOST:
-                proto = socket.AF_INET6
-            s = socket.socket(proto, socket.SOCK_STREAM)
-            s.settimeout(self.config.getint(self.section, 'timeout'))
+            host = self.config.get(self.section, 'host')
+            port = int(self.config.get(self.section, 'port'))
+            timeout = int(self.config.get(self.section, 'timeout'))
             try:
-                s.connect((icap_HOST, icap_PORT))
+                s = socket.create_connection((host, port), timeout)
             except socket.error:
                 raise Exception(
-                    'Could not reach ICAP server using network (%s, %s)' % (icap_HOST, icap_PORT))
+                    'Could not reach ICAP server using network (%s, %s)' % (host, port))
 
         return s
 
@@ -293,3 +289,4 @@ AAEAAQA3AAAAbQAAAAAA
             return False
         print("ICAP server found virus", result)
         return True
+

--- a/fuglu/src/fuglu/plugins/sa.py
+++ b/fuglu/src/fuglu/plugins/sa.py
@@ -76,7 +76,7 @@ Tags:
                 'default': '256000',
                 'description': "maximum size in bytes. larger messages will be skipped",
             },
-            
+
             'strip_oversize':{
                 'default': '0',
                 'description': "enable scanning of messages larger than maxsize. all attachments will be stripped and only headers, plaintext and html part will be scanned. If message is still oversize it will be truncated",
@@ -136,13 +136,13 @@ Tags:
                 'default': '0',
                 'description': "consult spamassassins(or any other) sql blacklist for messages that are too big for spam checks\nrequires the sql extension to be enabled",
             },
-            
+
             'sql_blacklist_dbconnectstring': {
                 'default': 'mysql:///localhost/spamassassin',
                 'description': "sqlalchemy db connect string",
                 'confidential': True,
             },
-            
+
             'sql_blacklist_sql': {
                 'default': """SELECT value FROM userpref WHERE prefid='blacklist_from' AND username in ('$GLOBAL',concat('%',${to_domain}),${to_address})""",
                 'description': "SQL query to get the blacklist entries for a suspect\nyou may use template variables: ${from_address} ${from_domain} ${to_address} ${to_domain}",
@@ -150,26 +150,26 @@ Tags:
 
         }
         self.logger = self._logger()
-    
-    
+
+
     def __str__(self):
         return "SpamAssassin"
-    
-    
+
+
     def lint(self):
         allok = (self.checkConfig() and self.lint_ping()
                  and self.lint_spam() and self.lint_blacklist())
         return allok
-    
-    
+
+
     def lint_blacklist(self):
         if not self.config.has_option(self.section, 'check_sql_blacklist') or not self.config.getboolean(self.section, 'check_sql_blacklist'):
             return True
-        
+
         if not SQL_EXTENSION_ENABLED:
             print("SQL Blacklist requested but SQLALCHEMY is not enabled")
             return False
-        
+
         session = get_session(self.config.get(self.section, 'sql_blacklist_dbconnectstring'))
         suspect = Suspect('dummy@example.com', 'dummy@example.com', '/dev/null')
         conf_sql = self.config.get(self.section, 'sql_blacklist_sql')
@@ -181,8 +181,8 @@ Tags:
         except Exception as e:
             print(e)
             return False
-    
-    
+
+
     def lint_ping(self):
         """ping sa"""
         retries = self.config.getint(self.section, 'retries')
@@ -216,8 +216,8 @@ Tags:
 
             time.sleep(1)
         return False
-    
-    
+
+
     def lint_spam(self):
         spamflag, score, rules = self.safilter_symbols(GTUBE, 'test')
         if 'GTUBE' in rules:
@@ -226,8 +226,8 @@ Tags:
         else:
             print("SA did not detect GTUBE")
             return False
-    
-    
+
+
     def _replace_sql_params(self, suspect, conf_sql):
         """replace template variables in sql with parameters and set sqlalchemy parameters from suspect"""
         values = {}
@@ -248,18 +248,18 @@ Tags:
         }
 
         return sql, params
-    
-    
+
+
     def check_sql_blacklist(self, suspect, runtimeconfig=None):
         """Check this message against the SQL blacklist. returns highspamaction on hit, DUNNO otherwise"""
         #work in progress
         if not self.config.has_option(self.section, 'check_sql_blacklist') or not self.config.getboolean(self.section, 'check_sql_blacklist'):
             return DUNNO
-        
+
         if not SQL_EXTENSION_ENABLED:
             self.logger.error('Cannot check sql blacklist, SQLALCHEMY extension is not available')
             return DUNNO
-        
+
         try:
             dbsession = get_session(self.config.get(self.section, 'sql_blacklist_dbconnectstring'))
             conf_sql = self.config.get(self.section, 'sql_blacklist_sql')
@@ -269,7 +269,7 @@ Tags:
             self.logger.error('Could not read blacklist from DB: %s' % e)
             suspect.debug('Blacklist check failed: %s' % e)
             return DUNNO
-        
+
         for result in resultproxy:
             dbvalue = result[0]  # this value might have multiple words
             allvalues = dbvalue.split()
@@ -297,8 +297,8 @@ Tags:
                     return configaction
 
         return DUNNO
-    
-    
+
+
     def _problemcode(self):
         retcode = string_to_actioncode(
             self.config.get(self.section, 'problemaction'), self.config)
@@ -307,8 +307,8 @@ Tags:
         else:
             # in case of invalid problem action
             return DEFER
-    
-    
+
+
     def _extract_spamstatus(self, msgrep, spamheadername, suspect):
         """
         extract spamstatus and score from messages returned by spamassassin
@@ -342,13 +342,13 @@ Tags:
                 self.logger.warning('%s Could not extract spam score from header: %s' % (suspect.id, spamheader))
                 suspect.debug( 'Could not read spam score from header %s' % spamheader)
         return isspam, spamscore
-    
-    
+
+
     def _strip_attachments(self, content, maxsize):
         """
         strip all attachments from multipart mails except for plaintext and html text parts.
         if message is still too long, truncate.
-        
+
         Args:
             content: string containing message source
             maxsize: integer of maximum message size accepted by spamassassin
@@ -356,7 +356,7 @@ Tags:
         Returns: stripped and truncated message content
 
         """
-        
+
         msgrep = email.message_from_string(content)
 
         if msgrep.is_multipart():
@@ -373,27 +373,27 @@ Tags:
         else:
             # text only mail - keep full content and truncate later
             new_src = content
-        
+
         if len(new_src) > maxsize:
             # truncate to maxsize
             new_src = new_src[:maxsize-1]
-        
+
         return new_src
-    
-    
+
+
     def examine(self, suspect):
         # check if someone wants to skip sa checks
         if suspect.get_tag('SAPlugin.skip') is True:
             self.logger.debug('%s Skipping SA Plugin (requested by previous plugin)' % suspect.id)
             suspect.set_tag('SAPlugin.skipreason', 'requested by previous plugin')
             return DUNNO
-        
+
         runtimeconfig = DBConfig(self.config, suspect)
-        
+
         spamsize = suspect.size
         maxsize = self.config.getint(self.section, 'maxsize')
         strip_oversize = self.config.getboolean(self.section, 'strip_oversize')
-        
+
         if spamsize > maxsize and not strip_oversize:
             self.logger.info('%s Size Skip, %s > %s' % (suspect.id, spamsize, maxsize))
             suspect.debug('Too big for spamchecks. %s > %s' % (spamsize, maxsize))
@@ -401,15 +401,16 @@ Tags:
             suspect.addheader("%sSA-SKIP" % prependheader, 'Too big for spamchecks. %s > %s' % (spamsize, maxsize))
             suspect.set_tag('SAPlugin.skipreason', 'size skip')
             return self.check_sql_blacklist(suspect)
-        
+
         if self.config.getboolean(self.section, 'scanoriginal'):
             content = suspect.get_original_source()
         else:
             content = suspect.get_source()
-            
+
+        stripped = False
         if spamsize > maxsize:
             content = self._strip_attachments(content, maxsize)
-        
+
         # prepend temporary headers set by other plugins
         tempheader = suspect.get_tag('SAPlugin.tempheader')
         if tempheader is not None:
@@ -418,7 +419,7 @@ Tags:
             tempheader = tempheader.strip()
             if tempheader != '':
                 content = tempheader + '\r\n' + content
-        
+
         forwardoriginal = self.config.getboolean(self.section, 'forwardoriginal')
         if forwardoriginal:
             ret = self.safilter_report(content, suspect.to_address)
@@ -430,7 +431,7 @@ Tags:
                 return self._problemcode()
             isspam, spamscore, report = ret
             suspect.tags['SAPlugin.report'] = report
-        
+
         else:
             filtered = self.safilter(content, suspect.to_address)
             if filtered is None:
@@ -441,15 +442,15 @@ Tags:
                 return self._problemcode()
             else:
                 content = filtered
-            
+
             newmsgrep = email.message_from_string(content)
             suspect.set_source(content)
             spamheadername = self.config.get(self.section, 'spamheader')
             isspam, spamscore = self._extract_spamstatus(newmsgrep, spamheadername, suspect)
-        
+
         action = DUNNO
         message = None
-        
+
         if isspam:
             self.logger.debug('%s Message is spam' % suspect.id)
             suspect.debug('Message is spam')
@@ -464,7 +465,7 @@ Tags:
         else:
             self.logger.debug('%s Message is not spam' % suspect.id)
             suspect.debug('Message is not spam')
-        
+
         suspect.tags['spam']['SpamAssassin'] = isspam
         suspect.tags['highspam']['SpamAssassin'] = False
         if spamscore is not None:
@@ -476,16 +477,14 @@ Tags:
                 if configaction is not None:
                     action = configaction
         return action, message
-    
-    
+
+
     def __init_socket(self):
-        host = self.config.get(self.section, 'host')
         unixsocket = False
 
         try:
-            port = int(self.config.get(self.section, 'port'))
+            int(self.config.get(self.section, 'port'))
         except ValueError:
-            port = None
             unixsocket = True
 
         if unixsocket:
@@ -499,19 +498,17 @@ Tags:
             except socket.error:
                 raise Exception('Could not reach spamd using unix socket %s' % sock)
         else:
-            proto = socket.AF_INET
-            if ':' in host:
-                proto = socket.AF_INET6
-            s = socket.socket(proto, socket.SOCK_STREAM)
-            s.settimeout(self.config.getint(self.section, 'timeout'))
+            host = self.config.get(self.section, 'host')
+            port = int(self.config.get(self.section, 'port'))
+            timeout = self.config.getint(self.section, 'timeout')
             try:
-                s.connect((host, port))
+                s = socket.create_connection((host, port), timeout)
             except socket.error:
                 raise Exception('Could not reach spamd using network (%s, %s)' % (host, port))
 
         return s
-    
-    
+
+
     def safilter(self, messagecontent, user):
         """pass content to sa, return sa-processed mail"""
         retries = self.config.getint(self.section, 'retries')
@@ -563,8 +560,8 @@ Tags:
 
             time.sleep(1)
         return None
-    
-    
+
+
     def safilter_symbols(self, messagecontent, user):
         """Pass content to sa, return spamflag, score, rules"""
         ret = self._safilter_content(messagecontent, user, 'SYMBOLS')
@@ -575,12 +572,12 @@ Tags:
 
         rules = content.split(',')
         return status, score, rules
-    
-    
+
+
     def safilter_report(self, messagecontent, user):
         return self._safilter_content(messagecontent, user, 'REPORT')
-    
-    
+
+
     def _safilter_content(self, messagecontent, user, command):
         """pass content to sa, return body"""
         assert command in ['SYMBOLS', 'REPORT', ]
@@ -640,23 +637,21 @@ Tags:
 
             time.sleep(1)
         return None
-    
-    
+
+
     def debug_proto(self, messagecontent, command='SYMBOLS'):
         """proto debug.. only used for development"""
         command = command.upper()
         assert command in ['CHECK', 'SYMBOLS', 'REPORT',
                            'REPORT_IFSPAM', 'SKIP', 'PING', 'PROCESS', 'TELL']
 
-        serverHost = "127.0.0.1"
-        serverPort = 783
+        host = "127.0.0.1"
+        port = 783
         timeout = 20
 
         spamsize = len(messagecontent)
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-        s.settimeout(timeout)
-        s.connect((serverHost, serverPort))
+        s = socket.create_connection((host, port), timeout)
         s.sendall('%s SPAMC/1.2' % command)
         s.sendall("\r\n")
         s.sendall("Content-length: %s" % spamsize)
@@ -678,3 +673,4 @@ if __name__ == '__main__':
     print("--------------")
     plugin.debug_proto(GTUBE, sys.argv[1])
     print("--------------")
+

--- a/fuglu/src/fuglu/plugins/sssp.py
+++ b/fuglu/src/fuglu/plugins/sssp.py
@@ -128,7 +128,7 @@ def sayGoodbye(s):
 
 class SSSPPlugin(ScannerPlugin):
 
-    """ This plugin scans the suspect using the sophos SSSP protocol. 
+    """ This plugin scans the suspect using the sophos SSSP protocol.
 
 Prerequisites: Requires a running sophos daemon with dynamic interface (SAVDI)
 """
@@ -226,7 +226,7 @@ Prerequisites: Requires a running sophos daemon with dynamic interface (SAVDI)
                     i + 1, self.config.getint(self.section, 'retries'), str(e)))
         self.logger.error("SSSP scan failed after %s retries" %
                           self.config.getint(self.section, 'retries'))
-        
+
         return self._problemcode()
 
     def scan_stream(self, buf):
@@ -331,12 +331,10 @@ Prerequisites: Requires a running sophos daemon with dynamic interface (SAVDI)
             return dr
 
     def __init_socket__(self):
-        sssp_HOST = self.config.get(self.section, 'host')
         unixsocket = False
-        iport = None
 
         try:
-            iport = int(self.config.get(self.section, 'port'))
+            int(self.config.get(self.section, 'port'))
         except ValueError:
             unixsocket = True
 
@@ -352,17 +350,14 @@ Prerequisites: Requires a running sophos daemon with dynamic interface (SAVDI)
                 raise Exception(
                     'Could not reach SSSP server using unix socket %s' % sock)
         else:
-            sssp_PORT = iport
-            proto = socket.AF_INET
-            if ':' in sssp_HOST:
-                proto = socket.AF_INET6
-            s = socket.socket(proto, socket.SOCK_STREAM)
-            s.settimeout(self.config.getint(self.section, 'timeout'))
+            host = self.config.get(self.section, 'host')
+            port = int(self.config.get(self.section, 'port'))
+            timeout = self.config.getint(self.section, 'timeout')
             try:
-                s.connect((sssp_HOST, sssp_PORT))
+                s = socket.create_connection((host, port), timeout)
             except socket.error:
                 raise Exception(
-                    'Could not reach SSSP server using network (%s, %s)' % (sssp_HOST, sssp_PORT))
+                    'Could not reach SSSP server using network (%s, %s)' % (host, port))
 
         return s
 
@@ -404,3 +399,4 @@ AAEAAQA3AAAAbQAAAAAA
             return False
         print("SSSP server found virus", result)
         return True
+

--- a/fuglu/src/fuglu/protocolbase.py
+++ b/fuglu/src/fuglu/protocolbase.py
@@ -61,8 +61,10 @@ class BasicTCPServer(object):
         self.controller = controller
         self.stayalive = True
 
+        addr_f = socket.getaddrinfo(address, 0)[0][0]
+
         try:
-            self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._socket = socket.socket(addr_f, socket.SOCK_STREAM)
             self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             self._socket.bind((address, port))
             self._socket.listen(5)
@@ -126,3 +128,4 @@ def forking_dumps(obj):
     buf = StringIO()
     ForkingPickler(buf).dump(obj)
     return buf.getvalue()
+


### PR DESCRIPTION
We are moving all our infrastructure to IPv6 and need this a lot.
At the moment there is only AF_INET support all over.

I have replaced everything with socket.getaddrinfo() and socket.create_connection()
This should be enough to provide IPv4 and IPv6 support, looks cleaner too.