### PR TITLE
gitlab - enable python3 testing for master branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,7 @@ unittests_py3:
     - cd fuglu
     - nosetests-3.4 --rednose tests/unit
   only:
+    - master
     - python3
 
 integrationtests:
@@ -44,6 +45,7 @@ integrationtests_py3:
     - cd fuglu
     - nosetests-3.4 --rednose tests/integration
   only:
+    - master
     - python3
 
 
@@ -70,4 +72,5 @@ buildfuglu_py3:
     - mkdir -p /var/log/fuglu
     - chown nobody /var/log/fuglu
   only:
+    - master
     - python3


### PR DESCRIPTION
gitlab: enable python 3 tests for master branch now that the python3 branch has been merged to master